### PR TITLE
Add getClusterNameFromEndpoint function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
   - [getClusterConnection()](#getClusterConnection)
   - [getClusterName()](#getClusterName)
+  - [getClusterNameFromEndpoint()](#getClusterNameFromEndpoint)
 
   </details>
 
@@ -181,6 +182,22 @@ import { getClusterName } from 'solutils';
 const { clusterName } = getClusterName('mainnet-beta');
 
 console.log(clusterName); // "Mainnet"
+```
+
+##### getClusterNameFromEndpoint()
+
+_Definition_
+
+It returns the cluster name from any endpoint. This is especially useful when you want to know which cluster the user is on when they are using a custom endpoint.
+
+_Example_
+
+```typescript
+import { getClusterNameFromEndpoint } from 'solutils';
+
+const { clusterName } = await getClusterNameFromEndpoint('https://solana-api.projectserum.com');
+
+console.log(clusterName); // "mainnet-beta"
 ```
 
 ---

--- a/core/cluster.ts
+++ b/core/cluster.ts
@@ -1,6 +1,8 @@
 import { clusterApiUrl, Connection, Cluster } from '@solana/web3.js';
 
-export function getClusterConnection(cluster: Cluster): { connection: Connection } {
+export function getClusterConnection(cluster: Cluster): {
+  connection: Connection;
+} {
   const clusterUrl = clusterApiUrl(cluster);
   const connection = new Connection(clusterUrl);
 
@@ -16,4 +18,25 @@ export function getClusterName(cluster: Cluster): { clusterName: string } {
   const clusterName = clusterNames[cluster];
 
   return { clusterName };
+}
+
+export async function getClusterNameFromEndpoint(
+  endpoint: string
+): Promise<{ clusterName: Cluster | 'localnet' | 'unknown' }> {
+  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
+    return { clusterName: 'localnet' };
+  }
+
+  const connection = new Connection(endpoint);
+  const genesisHash = await connection.getGenesisHash();
+  switch (genesisHash) {
+    case 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG':
+      return { clusterName: 'devnet' };
+    case '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY':
+      return { clusterName: 'testnet' };
+    case '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d':
+      return { clusterName: 'mainnet-beta' };
+    default:
+      return { clusterName: 'unknown' };
+  }
 }


### PR DESCRIPTION
This PR adds support for `getClusterNameFromEndpoint` function. This is especially useful when you want to know which cluster the user is on when they are using a custom endpoint.