### PR TITLE
Lock web3.js to 1.x for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For full documentation and examples, visit [solutils.vercel.app](https://solutil
 Install solutils and its @solana peer dependencies.
 
 ```bash
-npm install @lndgalante/solutils @solana/web3.js @solana/spl-token @solana/wallet-adapter-react
+npm install @lndgalante/solutils @solana/web3.js@1 @solana/spl-token @solana/wallet-adapter-react
 ```
 
 ### Quick Start

--- a/docs/web/pages/index.mdx
+++ b/docs/web/pages/index.mdx
@@ -7,7 +7,7 @@ title: 'Solutils: React Hooks and Helpers for Solana.'
 ### React hooks and Helpers library for _Solana_
 
 ```bash
-yarn add @lndgalante/solutils @solana/web3.js @solana/spl-token @solana/wallet-adapter-react
+yarn add @lndgalante/solutils @solana/web3.js@1 @solana/spl-token @solana/wallet-adapter-react
 ```
 
 #### Overview


### PR DESCRIPTION
Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498